### PR TITLE
Update send-results-git.sh

### DIFF
--- a/mindreporter/send-results-git.sh
+++ b/mindreporter/send-results-git.sh
@@ -17,7 +17,7 @@ git pull origin $BRANCH_NAME
 git add $VERSION_DIR
 git commit -m "Experiment report $VERSION_NAME"
 
-if [ "$SEND_RESULT_WITH_GIT_PUSH" = "true" ];
+if [ "$SEND_RESULT_WITH_GIT_PUSH" = "true" ]; then
 	git push origin $BRANCH_NAME
 fi
 


### PR DESCRIPTION
When $SEND_RESULT_WITH_GIT_PUSH is true, a script error occurs.
